### PR TITLE
Fix the refcount of the iteration callback

### DIFF
--- a/_pyceres/core/callbacks.cc
+++ b/_pyceres/core/callbacks.cc
@@ -76,17 +76,4 @@ void init_callbacks(py::module& m) {
   py::class_<ceres::EvaluationCallback, PyEvaluationCallBack /* <--- trampoline*/>(
       m, "EvaluationCallback")
       .def(py::init<>());
-
-  auto vec_it_cb =
-      py::bind_vector<std::vector<ceres::IterationCallback*>>(m, "ListIterationCallback");
-
-  vec_it_cb.def(py::init<>([](py::list list) {
-                  std::vector<ceres::IterationCallback*> callbacks;
-                  for (auto& handle : list) {
-                    callbacks.push_back(handle.cast<ceres::IterationCallback*>());
-                  }
-                  return callbacks;
-                }),
-                py::keep_alive<1, 2>());
-  py::implicitly_convertible<py::list, std::vector<ceres::IterationCallback*>>();
 }

--- a/_pyceres/core/solver.cc
+++ b/_pyceres/core/solver.cc
@@ -46,7 +46,16 @@ void init_solver(py::module& m) {
       py::class_<ceres::Solver::Options>(m, "SolverOptions")
           .def(py::init<>())
           .def("IsValid", &s_options::IsValid)
-          .def_readwrite("callbacks", &s_options::callbacks)
+          .def_property(
+              "callbacks", [](const s_options& self) { return self.callbacks; },
+              py::cpp_function(
+                  [](s_options& self, py::list list) {
+                    std::vector<ceres::IterationCallback*> callbacks;
+                    for (auto& handle : list) {
+                      self.callbacks.push_back(handle.cast<ceres::IterationCallback*>());
+                    }
+                  },
+                  py::keep_alive<1, 2>()))
           .def_readwrite("minimizer_type", &s_options::minimizer_type)
           .def_readwrite("line_search_direction_type",
                          &s_options::line_search_direction_type)


### PR DESCRIPTION
Previously: Python needs to explicitly keep a reference to the callback during the solving. As such, this would cause a crash:
```python
options = pyceres.SolverOptions()
options.callback = [Callback()]
pyceres.solve(options, prob, summary)
```

Now: prevent Python from garbage-collect the callback object.