### PR TITLE
Fix compilation with Ceres v2.1

### DIFF
--- a/_pyceres/core/types.cc
+++ b/_pyceres/core/types.cc
@@ -136,8 +136,8 @@ void init_types(py::module& m) {
           .value("EIGEN_SPARSE", ceres::SparseLinearAlgebraLibraryType::EIGEN_SPARSE)
           .value("ACCELERATE_SPARSE",
                   ceres::SparseLinearAlgebraLibraryType::ACCELERATE_SPARSE)
-          .value("CUDA_SPARSE",
-                  ceres::SparseLinearAlgebraLibraryType::CUDA_SPARSE)
+        //   .value("CUDA_SPARSE",
+        //           ceres::SparseLinearAlgebraLibraryType::CUDA_SPARSE)
           .value("NO_SPARSE", ceres::SparseLinearAlgebraLibraryType::NO_SPARSE);
   AddStringToEnumConstructor(slalt);
 


### PR DESCRIPTION
- outcomment CUDA_SPARSE option which is only available in ceres 2.2