### PR TITLE
Update bundle.cc #include to match COLMAP changes

### DIFF
--- a/_pyceres/factors/bundle.cc
+++ b/_pyceres/factors/bundle.cc
@@ -1,4 +1,4 @@
-#include <colmap/base/camera_models.h>
+#include <colmap/camera/models.h>
 #include <colmap/base/projection.h>
 #include <colmap/util/types.h>
 

--- a/_pyceres/factors/bundle.cc
+++ b/_pyceres/factors/bundle.cc
@@ -1,5 +1,5 @@
 #include <colmap/camera/models.h>
-#include <colmap/base/projection.h>
+#include <colmap/geometry/projection.h>
 #include <colmap/util/types.h>
 
 #include <ceres/ceres.h>


### PR DESCRIPTION
COLMAP recently moved camera headers to their own folder; updated `#include` statement to reflect new location.
Tested example notebooks under `pyceres/examples` to verify change doesn't break basic functionality, but haven't tested beyond that.
Fixes [Issue #16](https://github.com/cvg/pyceres/issues/16)