### PR TITLE
fix compilation on clang

### DIFF
--- a/_pyceres/glog.cc
+++ b/_pyceres/glog.cc
@@ -30,7 +30,7 @@ void PyBindLogStack(const char* data, T size) {
   std::cerr << std::endl << std::endl << std::endl;
 }
 
-void PyBindLogTermination() {
+__attribute__((noreturn)) void PyBindLogTermination() {
   std::chrono::milliseconds timespan(2000);  // or whatever
   py::scoped_estream_redirect stream(
       std::cerr,                                // std::ostream&


### PR DESCRIPTION
Otherwise when compiled on MacOS, it generates the following error:

```
[ 50%] Building CXX object CMakeFiles/pyceres.dir/_pyceres/bindings.cc.o
In file included from /Users/dmytromishkin/dev/pyceres/_pyceres/bindings.cc:9:
/Users/dmytromishkin/dev/pyceres/_pyceres/glog.cc:81:45: error: cannot initialize a parameter of type 'google::logging_fail_func_t' (aka 'void (*)() __attribute__((noreturn))') with an rvalue of type 'void (*)()'
             google::InstallFailureFunction(&PyBindLogTermination);
                                            ^~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/include/glog/logging.h:642:61: note: passing argument to parameter 'fail_func' here
GLOG_EXPORT void InstallFailureFunction(logging_fail_func_t fail_func);
                                                            ^
In file included from /Users/dmytromishkin/dev/pyceres/_pyceres/bindings.cc:9:
/Users/dmytromishkin/dev/pyceres/_pyceres/glog.cc:86:50: error: cannot initialize a parameter of type 'google::logging_fail_func_t' (aka 'void (*)() __attribute__((noreturn))') with an rvalue of type 'void (*)()'
           []() { google::InstallFailureFunction(&PyBindLogTermination); });
                                                 ^~~~~~~~~~~~~~~~~~~~~
/opt/homebrew/include/glog/logging.h:642:61: note: passing argument to parameter 'fail_func' here
GLOG_EXPORT void InstallFailureFunction(logging_fail_func_t fail_func);
                                                            ^
2 errors generated.
make[2]: *** [CMakeFiles/pyceres.dir/_pyceres/bindings.cc.o] Error 1
make[1]: *** [CMakeFiles/pyceres.dir/all] Error 2
make: *** [all] Error 2
```