### PR TITLE
fix python cost

### DIFF
--- a/_pyceres/core/cost_functions.cc
+++ b/_pyceres/core/cost_functions.cc
@@ -124,6 +124,7 @@ void init_cost_functions(py::module& m) {
            })
       .def("parameter_block_sizes", &ceres::CostFunction::parameter_block_sizes,
            py::return_value_policy::reference)
+      .def("set_num_residuals", &PyCostFunction::set_num_residuals)
       .def("set_parameter_block_sizes",
            [](ceres::CostFunction& myself, std::vector<int32_t>& sizes) {
              for (auto s : sizes) {

--- a/examples/test_python_cost.py
+++ b/examples/test_python_cost.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pyceres
+
+
+# ref: examples/helloworld_analytic_diff.cc
+class HelloworldCostFunction(pyceres.CostFunction):
+    def __init__(self):
+        pyceres.CostFunction.__init__(self)
+        self.set_num_residuals(1)
+        self.set_parameter_block_sizes([1])
+
+    def Evaluate(self, parameters, residuals, jacobians):
+        x = parameters[0][0]
+        residuals[0] = 10. - x
+        if jacobians is not None:
+            jacobians[0][0] = -1.
+        return True
+
+
+def test_python_cost():
+    x = np.array(5.0)
+    x_ori = x.copy()
+    prob = pyceres.Problem()
+    cost = HelloworldCostFunction()
+    prob.add_residual_block(cost, None, [x])
+    options = pyceres.SolverOptions()
+    options.minimizer_progress_to_stdout = True
+    summary = pyceres.SolverSummary()
+    pyceres.solve(options, prob, summary)
+    print(summary.BriefReport())
+    print(f'{x_ori} -> {x}')
+
+
+if __name__ == "__main__":
+    test_python_cost()


### PR DESCRIPTION
Add wrapper for protected `CostFunction::set_num_residuals()` with `PyCostFunction::set_num_residuals()` to enable writing cost function in Python.

Ref: #22 