### PR TITLE
Add NormalError cost function

### DIFF
--- a/_pyceres/factors/bindings.h
+++ b/_pyceres/factors/bindings.h
@@ -17,8 +17,7 @@ inline Eigen::MatrixXd SqrtInformation(const Eigen::MatrixXd& covariance) {
 class NormalError {
  public:
   explicit NormalError(const Eigen::MatrixXd& covariance)
-      : sqrt_information_(SqrtInformation(covariance)),
-        dimension_(covariance.rows()) {
+      : sqrt_information_(SqrtInformation(covariance)) {
     THROW_CHECK_EQ(covariance.rows(), covariance.cols());
   }
 
@@ -34,18 +33,18 @@ class NormalError {
 
   template <typename T>
   bool operator()(T const* const* parameters, T* residuals_ptr) const {
-    for (int i = 0; i < dimension_; ++i) {
+    const int dimension = sqrt_information_.rows();
+    for (int i = 0; i < dimension; ++i) {
       residuals_ptr[i] = parameters[0][i] - parameters[1][i];
     }
     Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>> residuals(residuals_ptr,
-                                                              dimension_);
+                                                              dimension);
     residuals.applyOnTheLeft(sqrt_information_.template cast<T>());
     return true;
   }
 
  private:
   const Eigen::MatrixXd sqrt_information_;
-  const int dimension_;
 };
 
 void BindFactors(py::module& m) {

--- a/_pyceres/factors/bindings.h
+++ b/_pyceres/factors/bindings.h
@@ -9,16 +9,55 @@
 
 namespace py = pybind11;
 
+inline Eigen::MatrixXd SqrtInformation(const Eigen::MatrixXd& covariance) {
+  return covariance.inverse().llt().matrixL();
+}
+
+class NormalError {
+ public:
+  explicit NormalError(const Eigen::MatrixXd& covariance)
+      : sqrt_information_(SqrtInformation(covariance)),
+        dimension_(covariance.rows()) {
+    THROW_CHECK_EQ(covariance.rows(), covariance.cols());
+  }
+
+  static ceres::CostFunction* Create(const Eigen::MatrixXd& covariance) {
+    auto* cost_function = new ceres::DynamicAutoDiffCostFunction<NormalError>(
+        new NormalError(covariance));
+    const int dimension = covariance.rows();
+    cost_function->AddParameterBlock(dimension);
+    cost_function->AddParameterBlock(dimension);
+    cost_function->SetNumResiduals(dimension);
+    return cost_function;
+  }
+
+  template <typename T>
+  bool operator()(T const* const* parameters, T* residuals_ptr) const {
+    for (int i = 0; i < dimension_; ++i) {
+      residuals_ptr[i] = parameters[0][i] - parameters[1][i];
+    }
+    Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>> residuals(residuals_ptr,
+                                                              dimension_);
+    residuals.applyOnTheLeft(sqrt_information_.template cast<T>());
+    return true;
+  }
+
+ private:
+  const Eigen::MatrixXd sqrt_information_;
+  const int dimension_;
+};
+
 void BindFactors(py::module& m) {
   m.def(
       "NormalPrior",
       [](const Eigen::VectorXd& mean,
-         const Eigen::Matrix<double, -1, -1>& covariance) {
+         const Eigen::MatrixXd& covariance) -> ceres::CostFunction* {
         THROW_CHECK_EQ(covariance.cols(), mean.size());
         THROW_CHECK_EQ(covariance.cols(), covariance.rows());
-        return new ceres::NormalPrior(covariance.inverse().llt().matrixL(),
-                                      mean);
+        return new ceres::NormalPrior(SqrtInformation(covariance), mean);
       },
       py::arg("mean"),
       py::arg("covariance"));
+
+  m.def("NormalError", &NormalError::Create, py::arg("covariance"));
 }

--- a/_pyceres/factors/bindings.h
+++ b/_pyceres/factors/bindings.h
@@ -13,6 +13,7 @@ inline Eigen::MatrixXd SqrtInformation(const Eigen::MatrixXd& covariance) {
   return covariance.inverse().llt().matrixL();
 }
 
+// Mahalanobis squared distance between two parameters.
 class NormalError {
  public:
   explicit NormalError(const Eigen::MatrixXd& covariance)


### PR DESCRIPTION
Mahalanobis distance between two parameters.

Example:
```python
x1 = np.zeros(3)
x2 = np.ones(3)
x1_prior = np.arange(3)
covar = np.eye(3)

prob = pyceres.Problem()
loss = pyceres.TrivialLoss()
prob.add_residual_block(pyceres.factors.NormalPrior(x1_prior, covar), loss, [x1])
prob.add_residual_block(pyceres.factors.NormalError(covar), loss, [x1, x2])

options = pyceres.SolverOptions()
summary = pyceres.SolverSummary()
pyceres.solve(options, prob, summary)
np.testing.assert_allclose(x1, x1_prior, atol=1e-7)
np.testing.assert_allclose(x2, x1, atol=1e-7)
```