### PR TITLE
Use shared_ptr holder for Problem

### DIFF
--- a/_pyceres/core/problem.h
+++ b/_pyceres/core/problem.h
@@ -52,7 +52,7 @@ void BindProblem(py::module& m) {
 
   py::class_<ResidualBlockIDWrapper> residual_block_wrapper(m, "ResidualBlock");
 
-  py::class_<ceres::Problem>(m, "Problem")
+  py::class_<ceres::Problem, std::shared_ptr<ceres::Problem>>(m, "Problem")
       .def(py::init(&CreatePythonProblem))
       .def(py::init<ceres::Problem::Options>())
       .def("num_parameter_blocks", &ceres::Problem::NumParameterBlocks)


### PR DESCRIPTION
@B1ueber2y Without this fix, the following code results in a segfault for me:
```python
ba = pycolmap.BundleAdjuster()
pb = ba.problem
del pb
```
The shared pointer returned by `BundleAdjuster.problem` is lost if `pyceres.Problem` is not declared to use the shared pointer holder.