### PR TITLE
Support evaluation on residuals and Jacobian from pyceres.Problem

### DIFF
--- a/_pyceres/core/bindings.h
+++ b/_pyceres/core/bindings.h
@@ -3,6 +3,7 @@
 #include "_pyceres/core/callbacks.h"
 #include "_pyceres/core/cost_functions.h"
 #include "_pyceres/core/covariance.h"
+#include "_pyceres/core/crs_matrix.h"
 #include "_pyceres/core/loss_functions.h"
 #include "_pyceres/core/manifold.h"
 #include "_pyceres/core/problem.h"
@@ -17,6 +18,7 @@ void BindCore(py::module& m) {
   BindTypes(m);
   BindCallbacks(m);
   BindCovariance(m);
+  BindCRSMatrix(m);
   BindSolver(m);
   BindLossFunctions(m);
   BindCostFunctions(m);

--- a/_pyceres/core/crs_matrix.h
+++ b/_pyceres/core/crs_matrix.h
@@ -24,16 +24,8 @@ py::tuple ConvertCRSToPyTuple(const ceres::CRSMatrix& crsMatrix) {
     }
   }
 
-  // convert std::vector data to py::array_t
-  py::array_t<int> rows_array(rows.size());
-  py::array_t<int> cols_array(cols.size());
-  py::array_t<double> values_array(values.size());
-  std::copy(rows.begin(), rows.end(), rows_array.mutable_data());
-  std::copy(cols.begin(), cols.end(), cols_array.mutable_data());
-  std::copy(values.begin(), values.end(), values_array.mutable_data());
-
   // return as a tuple
-  return py::make_tuple(rows_array, cols_array, values_array);
+  return py::make_tuple(rows, cols, values);
 }
 }  // namespace
 

--- a/_pyceres/core/crs_matrix.h
+++ b/_pyceres/core/crs_matrix.h
@@ -17,9 +17,9 @@ py::tuple ConvertCRSToPyTuple(const ceres::CRSMatrix& crsMatrix) {
   py::array_t<int> rows(n_values), cols(n_values);
   py::array_t<double> values(n_values);
 
-  int* rows_data = static_cast<int*>(rows.request().ptr);
-  int* cols_data = static_cast<int*>(cols.request().ptr);
-  double* values_data = static_cast<double*>(values.request().ptr);
+  int* const rows_data = static_cast<int*>(rows.request().ptr);
+  int* const cols_data = static_cast<int*>(cols.request().ptr);
+  double* const values_data = static_cast<double*>(values.request().ptr);
 
   int counter = 0;
   for (int row = 0; row < crsMatrix.num_rows; ++row) {

--- a/_pyceres/core/crs_matrix.h
+++ b/_pyceres/core/crs_matrix.h
@@ -4,9 +4,9 @@
 #include "_pyceres/helpers.h"
 #include "_pyceres/logging.h"
 
+#include <Eigen/Sparse>
 #include <ceres/ceres.h>
 #include <ceres/crs_matrix.h>
-#include <Eigen/Sparse>
 #include <pybind11/pybind11.h>
 
 namespace py = pybind11;
@@ -15,7 +15,7 @@ namespace {
 py::tuple ConvertCRSToPyTuple(const ceres::CRSMatrix& crsMatrix) {
   std::vector<int> rows, cols;
   std::vector<double> values;
-  
+
   for (int row = 0; row < crsMatrix.num_rows; ++row) {
     for (int k = crsMatrix.rows[row]; k < crsMatrix.rows[row + 1]; ++k) {
       rows.push_back(row);
@@ -32,23 +32,20 @@ py::tuple ConvertCRSToPyTuple(const ceres::CRSMatrix& crsMatrix) {
   std::copy(cols.begin(), cols.end(), cols_array.mutable_data());
   std::copy(values.begin(), values.end(), values_array.mutable_data());
 
-  //return as a tulple
+  // return as a tuple
   return py::make_tuple(rows_array, cols_array, values_array);
 }
-}
+}  // namespace
 
 void BindCRSMatrix(py::module& m) {
   using CRSMatrix = ceres::CRSMatrix;
   py::class_<CRSMatrix> PyCRSMatrix(m, "CRSMatrix");
   PyCRSMatrix.def(py::init<>())
-    .def_readonly("num_rows", &CRSMatrix::num_rows)
-    .def_readonly("num_cols", &CRSMatrix::num_cols)
-    .def_readonly("rows", &CRSMatrix::rows)
-    .def_readonly("cols", &CRSMatrix::cols)
-    .def_readonly("values", &CRSMatrix::values)
-    .def("to_tuple", [](CRSMatrix& self) {
-        return ConvertCRSToPyTuple(self);
-    });
+      .def_readonly("num_rows", &CRSMatrix::num_rows)
+      .def_readonly("num_cols", &CRSMatrix::num_cols)
+      .def_readonly("rows", &CRSMatrix::rows)
+      .def_readonly("cols", &CRSMatrix::cols)
+      .def_readonly("values", &CRSMatrix::values)
+      .def("to_tuple",
+           [](CRSMatrix& self) { return ConvertCRSToPyTuple(self); });
 }
-
-

--- a/_pyceres/core/crs_matrix.h
+++ b/_pyceres/core/crs_matrix.h
@@ -13,7 +13,7 @@ namespace py = pybind11;
 
 namespace {
 py::tuple ConvertCRSToPyTuple(const ceres::CRSMatrix& crsMatrix) {
-  size_t n_values = crsMatrix.values.size();
+  const size_t n_values = crsMatrix.values.size();
   py::array_t<int> rows(n_values), cols(n_values);
   py::array_t<double> values(n_values);
 

--- a/_pyceres/core/crs_matrix.h
+++ b/_pyceres/core/crs_matrix.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "_pyceres/core/wrappers.h"
+#include "_pyceres/helpers.h"
+#include "_pyceres/logging.h"
+
+#include <ceres/ceres.h>
+#include <ceres/crs_matrix.h>
+#include <Eigen/Sparse>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+namespace {
+py::tuple ConvertCRSToPyTuple(const ceres::CRSMatrix& crsMatrix) {
+  std::vector<int> rows, cols;
+  std::vector<double> values;
+  
+  for (int row = 0; row < crsMatrix.num_rows; ++row) {
+    for (int k = crsMatrix.rows[row]; k < crsMatrix.rows[row + 1]; ++k) {
+      rows.push_back(row);
+      cols.push_back(crsMatrix.cols[k]);
+      values.push_back(crsMatrix.values[k]);
+    }
+  }
+
+  // convert std::vector data to py::array_t
+  py::array_t<int> rows_array(rows.size());
+  py::array_t<int> cols_array(cols.size());
+  py::array_t<double> values_array(values.size());
+  std::copy(rows.begin(), rows.end(), rows_array.mutable_data());
+  std::copy(cols.begin(), cols.end(), cols_array.mutable_data());
+  std::copy(values.begin(), values.end(), values_array.mutable_data());
+
+  //return as a tulple
+  return py::make_tuple(rows_array, cols_array, values_array);
+}
+}
+
+void BindCRSMatrix(py::module& m) {
+  using CRSMatrix = ceres::CRSMatrix;
+  py::class_<CRSMatrix> PyCRSMatrix(m, "CRSMatrix");
+  PyCRSMatrix.def(py::init<>())
+    .def_readonly("num_rows", &CRSMatrix::num_rows)
+    .def_readonly("num_cols", &CRSMatrix::num_cols)
+    .def_readonly("rows", &CRSMatrix::rows)
+    .def_readonly("cols", &CRSMatrix::cols)
+    .def_readonly("values", &CRSMatrix::values)
+    .def("to_tuple", [](CRSMatrix& self) {
+        return ConvertCRSToPyTuple(self);
+    });
+}
+
+

--- a/_pyceres/core/problem.h
+++ b/_pyceres/core/problem.h
@@ -235,10 +235,10 @@ void BindProblem(py::module& m) {
              self.RemoveResidualBlock(residual_block_id.id);
            })
       .def("evaluate_jacobian",
-          [](ceres::Problem& self, const ceres::Problem::EvaluateOptions& options) {
-            ceres::CRSMatrix jacobian;
-            self.Evaluate(options, nullptr, nullptr, nullptr, &jacobian);
-            return jacobian;
-          }
-          );
+           [](ceres::Problem& self,
+              const ceres::Problem::EvaluateOptions& options) {
+             ceres::CRSMatrix jacobian;
+             self.Evaluate(options, nullptr, nullptr, nullptr, &jacobian);
+             return jacobian;
+           });
 }

--- a/_pyceres/core/problem.h
+++ b/_pyceres/core/problem.h
@@ -233,5 +233,12 @@ void BindProblem(py::module& m) {
       .def("remove_residual_block",
            [](ceres::Problem& self, ResidualBlockIDWrapper& residual_block_id) {
              self.RemoveResidualBlock(residual_block_id.id);
-           });
+           })
+      .def("evaluate_jacobian",
+          [](ceres::Problem& self, const ceres::Problem::EvaluateOptions& options) {
+            ceres::CRSMatrix jacobian;
+            self.Evaluate(options, nullptr, nullptr, nullptr, &jacobian);
+            return jacobian;
+          }
+          );
 }

--- a/_pyceres/core/problem.h
+++ b/_pyceres/core/problem.h
@@ -42,13 +42,15 @@ void BindProblem(py::module& m) {
 
   py::class_<ceres::Problem::EvaluateOptions>(m, "EvaluateOptions")
       .def(py::init<>())
-      .def("set_parameter_blocks", [](ceres::Problem::EvaluateOptions& self, std::vector<py::array_t<double>>& blocks) {
-            self.parameter_blocks.clear();
-            for (auto it = blocks.begin(); it != blocks.end(); ++it) {
-              py::buffer_info info = it->request();
-              self.parameter_blocks.push_back(static_cast<double*>(info.ptr));
-            }
-          })
+      .def("set_parameter_blocks",
+           [](ceres::Problem::EvaluateOptions& self,
+              std::vector<py::array_t<double>>& blocks) {
+             self.parameter_blocks.clear();
+             for (auto it = blocks.begin(); it != blocks.end(); ++it) {
+               py::buffer_info info = it->request();
+               self.parameter_blocks.push_back(static_cast<double*>(info.ptr));
+             }
+           })
       .def_readwrite("apply_loss_function",
                      &ceres::Problem::EvaluateOptions::apply_loss_function)
       .def_readwrite("num_threads",
@@ -238,20 +240,22 @@ void BindProblem(py::module& m) {
            [](ceres::Problem& self, ResidualBlockIDWrapper& residual_block_id) {
              self.RemoveResidualBlock(residual_block_id.id);
            })
-      .def("evaluate_residuals",
+      .def(
+          "evaluate_residuals",
           [](ceres::Problem& self,
-              const ceres::Problem::EvaluateOptions& options) {
-             std::vector<double> residuals;
-             self.Evaluate(options, nullptr, &residuals, nullptr, nullptr);
-             return residuals;
-           },
-           py::arg("options") = ceres::Problem::EvaluateOptions())
-      .def("evaluate_jacobian",
-           [](ceres::Problem& self,
-              const ceres::Problem::EvaluateOptions& options) {
-             ceres::CRSMatrix jacobian;
-             self.Evaluate(options, nullptr, nullptr, nullptr, &jacobian);
-             return jacobian;
-           },
-           py::arg("options") = ceres::Problem::EvaluateOptions());
+             const ceres::Problem::EvaluateOptions& options) {
+            std::vector<double> residuals;
+            self.Evaluate(options, nullptr, &residuals, nullptr, nullptr);
+            return residuals;
+          },
+          py::arg("options") = ceres::Problem::EvaluateOptions())
+      .def(
+          "evaluate_jacobian",
+          [](ceres::Problem& self,
+             const ceres::Problem::EvaluateOptions& options) {
+            ceres::CRSMatrix jacobian;
+            self.Evaluate(options, nullptr, nullptr, nullptr, &jacobian);
+            return jacobian;
+          },
+          py::arg("options") = ceres::Problem::EvaluateOptions());
 }

--- a/_pyceres/core/problem.h
+++ b/_pyceres/core/problem.h
@@ -40,11 +40,15 @@ void BindProblem(py::module& m) {
       .def_readwrite("disable_all_safety_checks",
                      &options::disable_all_safety_checks);
 
-  // TODO: bind Problem::Evaluate
   py::class_<ceres::Problem::EvaluateOptions>(m, "EvaluateOptions")
       .def(py::init<>())
-      // Doesn't make sense to wrap this as you can't see the pointers in python
-      //.def_readwrite("parameter_blocks",&ceres::Problem::EvaluateOptions)
+      .def("set_parameter_blocks", [](ceres::Problem::EvaluateOptions& self, std::vector<py::array_t<double>>& blocks) {
+            self.parameter_blocks.clear();
+            for (auto it = blocks.begin(); it != blocks.end(); ++it) {
+              py::buffer_info info = it->request();
+              self.parameter_blocks.push_back(static_cast<double*>(info.ptr));
+            }
+          })
       .def_readwrite("apply_loss_function",
                      &ceres::Problem::EvaluateOptions::apply_loss_function)
       .def_readwrite("num_threads",
@@ -234,11 +238,20 @@ void BindProblem(py::module& m) {
            [](ceres::Problem& self, ResidualBlockIDWrapper& residual_block_id) {
              self.RemoveResidualBlock(residual_block_id.id);
            })
+      .def("evaluate_residuals",
+          [](ceres::Problem& self,
+              const ceres::Problem::EvaluateOptions& options) {
+             std::vector<double> residuals;
+             self.Evaluate(options, nullptr, &residuals, nullptr, nullptr);
+             return residuals;
+           },
+           py::arg("options") = ceres::Problem::EvaluateOptions())
       .def("evaluate_jacobian",
            [](ceres::Problem& self,
               const ceres::Problem::EvaluateOptions& options) {
              ceres::CRSMatrix jacobian;
              self.Evaluate(options, nullptr, nullptr, nullptr, &jacobian);
              return jacobian;
-           });
+           },
+           py::arg("options") = ceres::Problem::EvaluateOptions());
 }


### PR DESCRIPTION
Also support partial evaluation.

Example with the NormalCost:

```
x1 = np.zeros(3)
x2 = np.ones(3)
x1_prior = np.arange(3)
covar = np.eye(3)
prob = pyceres.Problem()
loss = pyceres.TrivialLoss()
prob.add_residual_block(pyceres.factors.NormalPrior(x1_prior, covar), loss, [x1])
prob.add_residual_block(pyceres.factors.NormalError(covar), loss, [x1, x2])
print(prob.evaluate_residuals())
# Output:
# [0.0, -1.0, -2.0, -1.0, -1.0, -1.0]

options = pyceres.SolverOptions()
summary = pyceres.SolverSummary()
pyceres.solve(options, prob, summary)

# Example: full evaluation
eval_options = pyceres.EvaluateOptions()
jacobian = prob.evaluate_jacobian(eval_options)
rows, cols, values = jacobian.to_tuple()
sparse_matrix = scipy.sparse.coo_matrix((values, (rows, cols)), shape=(6, 6))
print(sparse_matrix.toarray())
# Output:
# [[ 1.  0.  0.  0.  0.  0. ]
#  [ 0.  1.  0.  0.  0.  0. ]
#  [ 0.  0.  1.  0.  0.  0. ]
#  [ 1.  0.  0. -1.  0.  0. ]
#  [ 0.  1.  0.  0. -1.  0. ]
#  [ 0.  0.  1.  0.  0. -1. ]]

 # Example: partial evaluation
eval_options.set_parameter_blocks([x2])
jacobian = prob.evaluate_jacobian(eval_options)
rows, cols, values = jacobian.to_tuple()
sparse_matrix = scipy.sparse.coo_matrix((values, (rows, cols)), shape=(6, 3))
print(sparse_matrix.toarray())
# Output:
# [[  0.  0.  0. ]
#  [  0.  0.  0. ]
#  [  0.  0.  0. ]
#  [ -1.  0.  0. ]
#  [  0. -1.  0. ]
#  [  0.  0. -1. ]]
```