### PR TITLE
Support residual evaluation from ceres::Problem

### DIFF
--- a/_pyceres/core/problem.h
+++ b/_pyceres/core/problem.h
@@ -11,6 +11,7 @@ namespace py = pybind11;
 
 namespace {
 
+// Set residual blocks for Ceres::Problem::EvaluateOptions
 void SetResidualBlocks(
     ceres::Problem::EvaluateOptions& self,
     std::vector<ResidualBlockIDWrapper>& residual_block_ids) {


### PR DESCRIPTION
Follow up for https://github.com/cvg/pyceres/pull/49. We can evaluate residuals either with ``EvaluateOptions`` or a list of residual ids.

Example:
```
import pyceres
import numpy as np

x1 = np.zeros(3)
x2 = np.ones(3)
x1_prior = np.arange(3)
covar = np.eye(3)
prob = pyceres.Problem()
loss = pyceres.TrivialLoss()
rid1 = prob.add_residual_block(pyceres.factors.NormalPrior(x1_prior, covar), loss, [x1])
rid2 = prob.add_residual_block(pyceres.factors.NormalError(covar), loss, [x1, x2])
print(prob.evaluate_residuals())
# Output:
# [0.0, -1.0, -2.0, -1.0, -1.0, -1.0]
print(prob.evaluate_residuals([rid2]))
# Output:
# [-1.0, -1.0, -1.0]
```