### PR TITLE
Bump version to 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pyceres"
-version = "2.3"
+version = "2.4"
 description="Factor graph optimization with Ceres, in Python"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
So far we've increased the version count right before creating a new release. This is wrong - we should do so right *after* creating the release. 