### PR TITLE
Add copy constructor support for solver bindings

### DIFF
--- a/_pyceres/core/solver.h
+++ b/_pyceres/core/solver.h
@@ -16,8 +16,9 @@ void BindSolver(py::module& m) {
         py::call_guard<py::gil_scoped_release>());
 
   using Options = ceres::Solver::Options;
-  py::class_<Options> PyOptions(m, "SolverOptions");
+  py::class_<Options, std::shared_ptr<Options>> PyOptions(m, "SolverOptions");
   PyOptions.def(py::init<>())
+      .def(py::init<const Options&>())
       .def("IsValid", &Options::IsValid)
       .def_property(
           "callbacks",
@@ -131,8 +132,9 @@ void BindSolver(py::module& m) {
   MakeDataclass(PyOptions);
 
   using Summary = ceres::Solver::Summary;
-  py::class_<Summary> PySummary(m, "SolverSummary");
+  py::class_<Summary, std::shared_ptr<Summary>> PySummary(m, "SolverSummary");
   PySummary.def(py::init<>())
+      .def(py::init<const Summary&>())
       .def("BriefReport", &Summary::BriefReport)
       .def("FullReport", &Summary::FullReport)
       .def("IsSolutionUsable", &Summary::IsSolutionUsable)
@@ -231,8 +233,10 @@ void BindSolver(py::module& m) {
   MakeDataclass(PySummary);
 
   using IterSummary = ceres::IterationSummary;
-  py::class_<IterSummary> PyIterSummary(m, "IterationSummary");
+  py::class_<IterSummary, std::shared_ptr<IterSummary>> PyIterSummary(
+      m, "IterationSummary");
   PyIterSummary.def(py::init<>())
+      .def(py::init<IterSummary>())
       .def_readonly("iteration", &IterSummary::iteration)
       .def_readonly("step_is_valid", &IterSummary::step_is_valid)
       .def_readonly("step_is_nonmonotonic", &IterSummary::step_is_nonmonotonic)

--- a/_pyceres/core/solver.h
+++ b/_pyceres/core/solver.h
@@ -236,7 +236,7 @@ void BindSolver(py::module& m) {
   py::class_<IterSummary, std::shared_ptr<IterSummary>> PyIterSummary(
       m, "IterationSummary");
   PyIterSummary.def(py::init<>())
-      .def(py::init<IterSummary>())
+      .def(py::init<const IterSummary&>())
       .def_readonly("iteration", &IterSummary::iteration)
       .def_readonly("step_is_valid", &IterSummary::step_is_valid)
       .def_readonly("step_is_nonmonotonic", &IterSummary::step_is_nonmonotonic)


### PR DESCRIPTION
Since we bring some of the Ceres bindings back to colmap from https://github.com/colmap/colmap/pull/2985, it s better to enable the copying behavior in Python, to be able to use features that in pyceres but not in pycolmap (for example, the callbacks in ``SolverOptions``). For example, the following code will work after this update:
```
import pycolmap
import pyceres
options_in_pycolmap = pycolmap.pyceres.SolverOptions()
options = pyceres.SolverOptions(options)
```

Also, the shared_ptr bindings support are added. 