### PR TITLE
Retire Python 3.8 and add support for 3.14. Update cibuildwheel to 3.1.2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
           echo "VCPKG_INSTALLATION_ROOT=${VCPKG_INSTALLATION_ROOT}" >> "$GITHUB_ENV"
           echo "CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" >> "$GITHUB_ENV"
 
-          # Fix: cibuildhweel cannot interpolate env variables.
+          # Fix: cibuildwheel cannot interpolate env variables.
           CONFIG_SETTINGS="cmake.define.CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
           CONFIG_SETTINGS="${CONFIG_SETTINGS} cmake.define.VCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}"
           echo "CIBW_CONFIG_SETTINGS_LINUX=${CONFIG_SETTINGS}" >> "$GITHUB_ENV"
@@ -119,11 +119,6 @@ jobs:
 
           CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux_2_28_x86_64"
           echo "CIBW_MANYLINUX_X86_64_IMAGE=${CIBW_MANYLINUX_X86_64_IMAGE}" >> "$GITHUB_ENV"
-      - name: Install ARM64 Python 3.8
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.8
-        if: runner.os == 'macOS' && runner.arch == 'ARM64' && ${{ matrix.config.arch }} == "arm64"
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
           python-version: 3.8
         if: runner.os == 'macOS' && runner.arch == 'ARM64' && ${{ matrix.config.arch }} == "arm64"
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.1.2
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.config.arch }}
       - name: Archive wheels

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository provides minimal Python bindings for the [Ceres Solver](http://c
 
 ## Installation
 
-Wheels for Python 8/9/10/11/12 on Linux, macOS 10+ (both Intel and Apple Silicon), and Windows can be installed using pip:
+Wheels for Python 9/10/11/12/13/14 on Linux, macOS 10+ (both Intel and Apple Silicon), and Windows can be installed using pip:
 ```bash
 pip install pyceres
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 license = {text = "Apache-2.0"}
 urls = {Repository = "https://github.com/cvg/pyceres"}
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = ["numpy"]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 [tool.cibuildwheel]
-build = "cp3{8,9,10,11,12,13}-{macosx,manylinux,win}*"
+build = "cp3{9,10,11,12,13,14}-{macosx,manylinux,win}*"
 archs = ["auto64"]
 test-command = "python -c \"import pyceres; print(pyceres.__version__)\""
 


### PR DESCRIPTION
To be consistent with https://github.com/colmap/colmap/pull/3518